### PR TITLE
Fix shooting skill

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="1657317661784587676" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1221298960296059740" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="1657317661784587676" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1221298960296059740" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Core/Src/shoot.c
+++ b/Core/Src/shoot.c
@@ -15,6 +15,8 @@ static int power = 100; 			// percentage of maximum shooting power
 // Stops and starts the timer for a certain period of time
 void resetTimer(int timePeriod);
 
+int calculateShootingTime(shoot_types type);
+
 ///////////////////////////////////////////////////// PUBLIC FUNCTION IMPLEMENTATIONS
 
 void shoot_Init(){
@@ -93,12 +95,12 @@ void shoot_Shoot(shoot_types type)
 	bool genevaNotTurning = (geneva_GetPWM() == 0);
 	if(shootState == shoot_Ready && genevaNotTurning)
 	{
-		//Putty_printf("shooting! power = %d \n\r", power);
+//		Putty_printf("shooting! power = %d \n\r", power);
 		shootState = shoot_Shooting;
 		set_Pin(Charge_pin, 0); 								// Disable shoot_Charging
 		set_Pin(type == shoot_Kick ? Kick_pin : Chip_pin, 1); 				// Kick/Chip on
 
-		resetTimer(power * ((type == shoot_Kick) ? KICK_TIME : CHIP_TIME));
+		resetTimer(calculateShootingTime(type));
 	}
 }
 
@@ -113,3 +115,11 @@ void resetTimer(int timePeriod)
 	HAL_TIM_Base_Start_IT(TIM_SHOOT);						// Start timer
 }
 
+int calculateShootingTime(shoot_types type) {
+	if (type == shoot_Kick) {
+		return ((1.0 - power/100.0) * MIN_KICK_TIME + (power/100.0) * MAX_KICK_TIME);
+	} else if (type == shoot_Chip) {
+		return ((1.0 - power/100.0) * MIN_CHIP_TIME + (power/100.0) * MAX_CHIP_TIME);
+	}
+	return 0;
+}

--- a/Util/control_util.h
+++ b/Util/control_util.h
@@ -54,8 +54,10 @@
 #define GENEVA_CAL_EDGE_CNT 4100	// the amount of encoder counts from one edge to the other
 
 // Shoot
-#define KICK_TIME 20 				// time period of kicking per percent of kicking power
-#define CHIP_TIME 30 				// time period of chipping per percent of chipping power
+#define MIN_KICK_TIME 25 				// minimum time period of kicking
+#define MAX_KICK_TIME 60 				// maximum time period of kicking
+#define MIN_CHIP_TIME 25 				// minimum time period of chipping
+#define MAX_CHIP_TIME 60 				// maximum time period of chipping
 #define TIMER_FREQ 10000 			// frequency [Hz] of TIM6  (Clock frequency divided by prescaler)
 #define READY_CALLBACK_FREQ 1 		// frequency [Hz] of callback when shootState is Ready
 #define CHARGING_CALLBACK_FREQ 10 	// frequency [Hz] of callback when shootState is Charging


### PR DESCRIPTION
Previously, shooting time was already at max when power was 3%. This fix makes it kick slow at 1% and fast at 100%. Calibration of this functionality still needs to be done when the kicker and chipper are fully finished.