### PR TITLE
Fix/geneva

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="202351054928855195" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1506764763353222015" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="202351054928855195" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1506764763353222015" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Core/Src/geneva.c
+++ b/Core/Src/geneva.c
@@ -104,10 +104,9 @@ int geneva_GetPWM(){
 ///////////////////////////////////////////////////// PRIVATE FUNCTION IMPLEMENTATIONS
 
 static void CheckIfStuck(){
-	static int margin = 3; // encoder margin within which the geneva is at a certain position
 	static uint tick = 0xFFFF;			//
 	static int enc = 0;
-	if(fabs(geneva_Encodervalue() - enc) < margin){
+	if(fabs(geneva_Encodervalue() - enc) < ENCODER_DEVIATION_MARGIN){
 		enc = geneva_Encodervalue();
 		tick = HAL_GetTick();
 	}else if(tick + 500 < HAL_GetTick()){
@@ -143,11 +142,10 @@ static void limitScale(){
 }
 
 static bool isResponding() {
-	static int margin = 5;	// margin within which encoder is considered to be the same as previous encoder
 	static bool result = true;
 	static int cnt = 0;
 	static int prevEncoder = 0;
-	if ((pwm > 0) && (fabs(geneva_Encodervalue() - prevEncoder)) < margin)  {
+	if ((pwm > 0) && (fabs(geneva_Encodervalue() - prevEncoder)) < ENCODER_DEVIATION_MARGIN)  {
 		cnt++;
 	} else {
 		cnt = 0;

--- a/Core/Src/geneva.c
+++ b/Core/Src/geneva.c
@@ -104,9 +104,10 @@ int geneva_GetPWM(){
 ///////////////////////////////////////////////////// PRIVATE FUNCTION IMPLEMENTATIONS
 
 static void CheckIfStuck(){
+	static int margin = 20; // encoder margin within which the geneva is at a certain position
 	static uint tick = 0xFFFF;			//
-	static int enc;
-	if(geneva_Encodervalue() != enc){
+	static int enc = 0;
+	if(fabs(geneva_Encodervalue() - enc) < margin){
 		enc = geneva_Encodervalue();
 		tick = HAL_GetTick();
 	}else if(tick + 500 < HAL_GetTick()){

--- a/Core/Src/geneva.c
+++ b/Core/Src/geneva.c
@@ -104,7 +104,7 @@ int geneva_GetPWM(){
 ///////////////////////////////////////////////////// PRIVATE FUNCTION IMPLEMENTATIONS
 
 static void CheckIfStuck(){
-	static int margin = 20; // encoder margin within which the geneva is at a certain position
+	static int margin = 3; // encoder margin within which the geneva is at a certain position
 	static uint tick = 0xFFFF;			//
 	static int enc = 0;
 	if(fabs(geneva_Encodervalue() - enc) < margin){

--- a/Core/Src/geneva.c
+++ b/Core/Src/geneva.c
@@ -143,7 +143,7 @@ static void limitScale(){
 }
 
 static bool isResponding() {
-	static margin = 5;	// margin within which encoder is considered to be the same as previous encoder
+	static int margin = 5;	// margin within which encoder is considered to be the same as previous encoder
 	static bool result = true;
 	static int cnt = 0;
 	static int prevEncoder = 0;

--- a/Core/Src/geneva.c
+++ b/Core/Src/geneva.c
@@ -143,10 +143,11 @@ static void limitScale(){
 }
 
 static bool isResponding() {
+	static margin = 5;	// margin within which encoder is considered to be the same as previous encoder
 	static bool result = true;
 	static int cnt = 0;
 	static int prevEncoder = 0;
-	if ((pwm > 0) && (geneva_Encodervalue() == prevEncoder)) {
+	if ((pwm > 0) && (fabs(geneva_Encodervalue() - prevEncoder)) < margin)  {
 		cnt++;
 	} else {
 		cnt = 0;

--- a/Util/control_util.h
+++ b/Util/control_util.h
@@ -52,6 +52,7 @@
 
 // Geneva
 #define GENEVA_CAL_EDGE_CNT 4100	// the amount of encoder counts from one edge to the other
+#define ENCODER_DEVIATION_MARGIN 3	// margin within which encoder is considered to be the same as previous encoder
 
 // Shoot
 #define MIN_KICK_TIME 25 				// minimum time period of kicking

--- a/robot3_newTopboard.cfg
+++ b/robot3_newTopboard.cfg
@@ -19,7 +19,7 @@ set ENABLE_LOW_POWER 1
 set STOP_WATCHDOG 1
 
 # STlink Debug clock frequency
-set CLOCK_FREQ 8000
+set CLOCK_FREQ 4000
 
 # use hardware reset, connect under reset
 # connect_assert_srst needed if low power mode application running (WFI...)


### PR DESCRIPTION
Fix geneva by adding a small margin to compensate for a difference in encoder values. This is used when calibrating the geneva and checking if it is responding.