### PR TITLE
Small fix for yaw calibration

### DIFF
--- a/Core/Src/stateEstimation.c
+++ b/Core/Src/stateEstimation.c
@@ -32,7 +32,7 @@ void stateEstimation_Update(StateInfo* input) {
 	float kalman_State[4] = {0.0f};
 	kalman_GetState(kalman_State);
 
-	yaw_Calibrate(input->xsensYaw, input->visionYaw, input->visionAvailable);
+	yaw_Calibrate(input->xsensYaw, input->visionYaw, input->visionAvailable, input->rateOfTurn);
 	float calibratedYaw = yaw_GetCalibratedYaw();
 
 	state[body_x] = kalman_State[0];

--- a/Lib/yawCalibration.c
+++ b/Lib/yawCalibration.c
@@ -26,7 +26,7 @@ static float getOldXsensYaw(float newXsensYaw);
 
 ///////////////////////////////////////////////////// PUBLIC FUNCTION IMPLEMENTATIONS
 
-void yaw_Calibrate(float newXsensYaw, float visionYaw, bool visionAvailable) {
+void yaw_Calibrate(float newXsensYaw, float visionYaw, bool visionAvailable, float rateOfTurn) {
 	static float yawOffset = 0.0f;
 	static int restCounter = 0;
 	static float sumXsensVec[2] = {0.0f};
@@ -35,7 +35,7 @@ void yaw_Calibrate(float newXsensYaw, float visionYaw, bool visionAvailable) {
 	// Calibrate the xsens yaw from some time ago with vision to account for delay while sending.
 	float oldXsensYaw = getOldXsensYaw(newXsensYaw);
 
-	if (isCalibrationNeeded(visionYaw, oldXsensYaw, yawOffset) && isRotatingSlow(visionYaw) && visionAvailable) {
+	if (isCalibrationNeeded(visionYaw, oldXsensYaw, yawOffset) && isRotatingSlow(rateOfTurn) && visionAvailable) {
 		if (restCounter > CALIBRATION_TIME / TIME_DIFF) {
 			// calculate offset
 			float avgVisionYaw = atan2f(sumVisionVec[1], sumVisionVec[0]);
@@ -91,23 +91,8 @@ static bool isCalibrationNeeded(float visionYaw, float xsensYaw, float yawOffset
 	return calibrationNeeded;
 }
 
-static bool isRotatingSlow(float visionYaw) {
-	static bool rotatingSlow = false;
-	static int rotateCounter = 0;
-	static float startYaw = 0;
-	if (fabs(constrainAngle(startYaw - visionYaw)) < (MAX_RATE_OF_TURN * TIME_DIFF)) {
-		rotateCounter++;
-	} else {
-		rotateCounter = 0;
-		startYaw = visionYaw;
-		rotatingSlow = false;
-	}
-	if (rotateCounter > 10) {
-		rotateCounter = 0;
-		startYaw = visionYaw;
-		rotatingSlow = true;
-	}
-	return rotatingSlow;
+static bool isRotatingSlow(float rateOfTurn) {
+	return fabs(rateOfTurn) < MAX_RATE_OF_TURN;
 }
 
 static float getOldXsensYaw(float newXsensYaw) {

--- a/Lib/yawCalibration.h
+++ b/Lib/yawCalibration.h
@@ -21,7 +21,7 @@
 ///////////////////////////////////////////////////// PUBLIC FUNCTION DECLARATIONS
 
 // Calibrate the state yaw with the vision yaw
-void yaw_Calibrate(float xsensYaw, float visionYaw, bool visionAvailable);
+void yaw_Calibrate(float xsensYaw, float visionYaw, bool visionAvailable, float rateOfTurn);
 
 // Getter for the yaw after calibration
 float yaw_GetCalibratedYaw();


### PR DESCRIPTION
The robot only calibrates is yaw with vision when it is rotating slow. Previously, this was checked by using vision data. In this pull request it is done with the gyroscope data from the xsens.